### PR TITLE
Trying to fix CKEditor tag stripping issue

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -30,6 +30,7 @@
 //= require jquery.datetimepicker
 //= require html.sortable
 //= require cocoon
+//= require_tree ./ckeditor
 
 
 var ready_ran = 0;

--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -1,0 +1,6 @@
+if (typeof(CKEDITOR) != undefined) {
+    CKEDITOR.editorConfig = function (config) {
+        config.extraAllowedContent = 'i'
+    }
+    CKEDITOR.dtd.$removeEmpty['i'] = false
+}


### PR DESCRIPTION
@miffyC noticed that CKEditor would strip empty `<i class="icon"></i>` tags, which is causing issues on site FAQ accordion. This probably fixes that, but I'm not too familiar with Rails. .___.)a
